### PR TITLE
Added zustand `pickFrom` transformer to pick a single item

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ module.exports = {
 ## Available plugins
 
 - [zustand-pick](https://github.com/bigbinary/babel-preset-neeto/blob/e8433f3a019cf96dcb0ea29d46393bcf5868406d/docs/zustand-pick.md)
+- [zustand-pick-from](https://github.com/bigbinary/babel-preset-neeto/blob/e8433f3a019cf96dcb0ea29d46393bcf5868406d/docs/zustand-pick-from.md)
 
 ## Other links
 

--- a/docs/zustand-pick-from.md
+++ b/docs/zustand-pick-from.md
@@ -1,0 +1,171 @@
+# Zustand pickFrom transformer
+
+## Motivation
+
+When we created the Zustand pick transformer, we did not take into account, the
+case to access a single property from a store. We were using the `pick`
+transformer to access a single item.
+
+```js
+const { order } = useGlobalStore.pick([sessionId, "globals"]);
+```
+
+While there doesn't seem to be an issue, with using it this way, at the time of
+bundling, the following is generated:
+
+```js
+import { shallow } from "zustand/shallow";
+
+const { order, customer } = useGlobalStore(
+  store => ({ order: store[sessionId]?.globals.order }),
+  shallow
+);
+```
+
+This gets the job done, but, it's very inefficient. Moreover, we don't even need
+the `shallow` import for picking a single property.
+
+For this reason, we have implemented the Zustand `pickFrom` transformer. The
+`pickFrom` transformer transpiles the code to an efficient version for picking a
+single item.
+
+```js
+const order = useGlobalStore.pickFrom([sessionId, "globals"]);
+```
+
+This will generate the following:
+
+```js
+const order = useGlobalStore.pickFrom(
+  store => store[sessionId]?.globals?.order
+);
+```
+
+## Allowed syntaxes
+
+Consider this zustand store as an example.
+
+```js
+const useGlobalStore = create((set, get) => ({
+  order: {
+    id: "#1230",
+    user: {
+      email: "oliver@example.com",
+      address: {
+        "location 1": { street: "293, 1st Floor", city: "Mumbai" }
+        "location 2": { street: "295, 3st Floor", city: "Chennai" }
+      },
+    },
+    items: {
+      // itemID: { ...properties }
+      "47e91f1a-0c4d-4a79-a939-1319d8659bd2": { quantity: 10, price: 100 },
+      "64b7e54c-5d8a-443a-b70b-fff3d6937eba": { quantity: 3, price: 34 },
+    },
+  },
+
+  setOrder: order => set({ order }),
+}));
+```
+
+```js
+// picks `order` data from the store
+const order = useGlobalStore.pickFrom();
+
+// picks `user` from inside store.order
+const user = useGlobalStore.pickFrom("order");
+
+// picks `quantity` of dynamically obtained item of id `itemId`
+const quantity = useGlobalStore.pickFrom(["order", "items", itemId]);
+```
+
+## Disallowed syntaxes
+
+We have introduced a type definition for `pickFrom` method from zustand stores
+from neeto-commons-frontend to make IDE capable of pointing out errors as you
+type. But it is not 100% foolproof. So here is a list of usages that are flagged
+as syntax errors during transpilation.
+
+1. Destructuring is not allowed. If you want to use destructuring, use the
+   `pick` method.
+
+   **incorrect**
+
+   ```js
+   const { user } = useGlobalStore.pickFrom();
+   ```
+
+   **correct**
+
+   ```js
+   const user = useGlobalStore.pickFrom("order");
+   ```
+
+2. Expressions are not allowed in picking path array
+
+   **incorrect**
+
+   ```js
+   // expressions are not allowed
+   const user = useGlobalStore.pickFrom(["order", index + 1]);
+   // string templates are not allowed
+   const user = useGlobalStore.pickFrom(["order", `#${orderId}`]);
+   ```
+
+   **correct**
+
+   ```js
+   // only use literals of String, Numbers or Booleans
+   // and variables as elements of the path array
+   const indexPlusOne = index + 1;
+   const user = useGlobalStore.pickFrom(["order", indexPlusOne, 0, true]);
+   ```
+
+3. PickFrom only accepts a single parameter:
+
+   **incorrect**
+
+   ```js
+   const name = useGlobalStore.pickFrom("order", "user");
+   ```
+
+   **correct**
+
+   ```js
+   // use arrays to specify nested path
+   const name = useGlobalStore.pickFrom(["order", "user"]);
+   // use key directly to get its nested properties.
+   const user = useGlobalStore.pickFrom("order");
+   // pass no arguments to get the top level properties
+   const order = useGlobalStore.pickFrom();
+   ```
+
+## Notes
+
+#### All nested property access are optional chained
+
+No need to worry if any of the properties in your store nesting may be
+null/undefined. This transformer adds optional chaining in all levels of
+nesting. That is:
+
+```js
+const order = useGlobalStore.pickFrom([sessionId, "globals"]);
+```
+
+Will be transformed to:
+
+```js
+const order = useGlobalStore(store => store[sessionId]?.["globals"]?.["order"]);
+```
+
+So your code won't fail if `store[sessionId]` is null or
+`store[sessionId].globals` is null.
+
+#### This plugin should run on user's code
+
+You might encounter errors if some other plugin transforms the code before
+babel-plugin-neeto. **babel-plugin-neeto expects that it runs first on the code
+before any other plugin performs transformations.**
+
+If your zustand-pick-from syntax is correct, and you are still getting errors,
+check for other babel-plugins or babel-presets transforming your code before we
+do.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const zustandPick = require("./src/plugins/zustand-pick");
+const zustandPickFrom = require("./src/plugins/zustand-pick-from");
 
 module.exports = () => ({
-  plugins: [zustandPick],
+  plugins: [zustandPick, zustandPickFrom],
 });

--- a/src/plugins/messages.js
+++ b/src/plugins/messages.js
@@ -3,6 +3,10 @@
 const INCORRECT_ZUSTAND_PICK_USAGE =
   "Invalid use of zustand store pick method. You can find a list of allowed usages here: https://bit.ly/zustand-pick-syntax";
 
+const INCORRECT_ZUSTAND_PICK_FROM_USAGE =
+  "Invalid use of zustand store pickFrom method. You can find a list of allowed usages here: https://bit.ly/zustand-pick-syntax";
+
 module.exports = {
   INCORRECT_ZUSTAND_PICK_USAGE,
+  INCORRECT_ZUSTAND_PICK_FROM_USAGE,
 };

--- a/src/plugins/messages.js
+++ b/src/plugins/messages.js
@@ -4,7 +4,7 @@ const INCORRECT_ZUSTAND_PICK_USAGE =
   "Invalid use of zustand store pick method. You can find a list of allowed usages here: https://bit.ly/zustand-pick-syntax";
 
 const INCORRECT_ZUSTAND_PICK_FROM_USAGE =
-  "Invalid use of zustand store pickFrom method. You can find a list of allowed usages here: https://bit.ly/zustand-pick-syntax";
+  "Invalid use of zustand store pickFrom method. You can find a list of allowed usages here: https://bit.ly/zustand-pick-from-syntax";
 
 module.exports = {
   INCORRECT_ZUSTAND_PICK_USAGE,

--- a/src/plugins/zustand-pick-from/constants.js
+++ b/src/plugins/zustand-pick-from/constants.js
@@ -1,0 +1,62 @@
+const { matches } = require("@bigbinary/neeto-commons-frontend/pure");
+const { test, isEmpty, mergeDeepLeft, includes, __ } = require("ramda");
+
+const { matchesWithLength } = require("../utils");
+
+const VALID_ARRAY_ELEMENT_TYPES = [
+  "StringLiteral",
+  "Identifier",
+  "NumericLiteral",
+  "BooleanLiteral",
+];
+
+const VALID_PICK_ARGUMENT_TYPES = [
+  "StringLiteral",
+  "Identifier",
+  "ArrayExpression",
+];
+
+const VALID_PICK_ARGUMENT = {
+  type: includes(__, VALID_PICK_ARGUMENT_TYPES),
+  elements: (elements, root) =>
+    root.type !== "ArrayExpression" ||
+    elements.every(({ type }) => VALID_ARRAY_ELEMENT_TYPES.includes(type)),
+};
+
+const PICK_FROM_GENERIC_PATTERN = {
+  type: "VariableDeclarator",
+  init: {
+    type: "CallExpression",
+    callee: {
+      type: "MemberExpression",
+      computed: false,
+      object: {
+        type: "Identifier",
+        name: test(/^use[a-zA-Z0-9]+Store$/),
+      },
+      property: {
+        type: "Identifier",
+        name: "pickFrom",
+      },
+    },
+  },
+};
+
+const PICK_FROM_STRICT_PATTERN = {
+  type: "VariableDeclaration",
+  declarations: matchesWithLength([
+    mergeDeepLeft(
+      {
+        id: { type: "Identifier" },
+        init: {
+          arguments: args =>
+            isEmpty(args) ||
+            (args.length === 1 && matches(VALID_PICK_ARGUMENT, args[0])),
+        },
+      },
+      PICK_FROM_GENERIC_PATTERN
+    ),
+  ]),
+};
+
+module.exports = { PICK_FROM_GENERIC_PATTERN, PICK_FROM_STRICT_PATTERN };

--- a/src/plugins/zustand-pick-from/index.js
+++ b/src/plugins/zustand-pick-from/index.js
@@ -1,0 +1,74 @@
+const { matches } = require("@bigbinary/neeto-commons-frontend/pure");
+const { last } = require("ramda");
+
+const {
+  PICK_FROM_GENERIC_PATTERN,
+  PICK_FROM_STRICT_PATTERN,
+} = require("./constants");
+
+const { INCORRECT_ZUSTAND_PICK_FROM_USAGE } = require("../messages");
+
+const getPropertyAccessNode = (types, propertyPath) => {
+  if (propertyPath.length === 1) {
+    return types.memberExpression(
+      types.identifier("store"),
+      propertyPath[0],
+      true
+    );
+  }
+
+  return types.optionalMemberExpression(
+    getPropertyAccessNode(
+      types,
+      propertyPath.slice(0, propertyPath.length - 1)
+    ),
+    last(propertyPath),
+    true,
+    true
+  );
+};
+
+module.exports = function ({ types }) {
+  return {
+    name: "Zustand pick-from transformer",
+    visitor: {
+      VariableDeclaration(astPath) {
+        const declaratorPath = astPath.get("declarations.0");
+        const declarator = declaratorPath.node;
+        if (!matches(PICK_FROM_GENERIC_PATTERN, declarator)) return;
+
+        if (!matches(PICK_FROM_STRICT_PATTERN, astPath.node)) {
+          throw astPath.buildCodeFrameError(INCORRECT_ZUSTAND_PICK_FROM_USAGE);
+        }
+
+        const [argument] = declarator.init.arguments;
+        let propertyPath;
+        if (argument === undefined) {
+          propertyPath = [];
+        } else if (["Identifier", "StringLiteral"].includes(argument.type)) {
+          propertyPath = [argument];
+        } else if (argument.type === "ArrayExpression") {
+          propertyPath = argument.elements;
+        } else return;
+
+        declarator.init = types.callExpression(
+          types.identifier(declarator.init.callee.object.name),
+          [
+            types.arrowFunctionExpression(
+              [types.identifier("store")],
+              getPropertyAccessNode(types, [
+                ...propertyPath,
+                types.stringLiteral(declarator.id.name),
+              ])
+            ),
+          ]
+        );
+      },
+      CallExpression(astPath) {
+        if (matches(PICK_FROM_GENERIC_PATTERN.init, astPath.node)) {
+          throw astPath.buildCodeFrameError(INCORRECT_ZUSTAND_PICK_FROM_USAGE);
+        }
+      },
+    },
+  };
+};

--- a/src/tests/zustand-pick-from/no-changes/non-pick-from-calls.js
+++ b/src/tests/zustand-pick-from/no-changes/non-pick-from-calls.js
@@ -1,0 +1,1 @@
+const name = useSampleStore.pock();

--- a/src/tests/zustand-pick-from/no-changes/non-standard-zustand-store.js
+++ b/src/tests/zustand-pick-from/no-changes/non-standard-zustand-store.js
@@ -1,0 +1,1 @@
+const name = useSampleStor.pickFrom();

--- a/src/tests/zustand-pick-from/syntax-errors/direct-pick-from-access1.js
+++ b/src/tests/zustand-pick-from/syntax-errors/direct-pick-from-access1.js
@@ -1,0 +1,1 @@
+const name = useGlobalStore.pickFrom("order").user;

--- a/src/tests/zustand-pick-from/syntax-errors/direct-pick-from-access2.js
+++ b/src/tests/zustand-pick-from/syntax-errors/direct-pick-from-access2.js
@@ -1,0 +1,1 @@
+const name = useGlobalStore.pickFrom("order")?.user.name;

--- a/src/tests/zustand-pick-from/syntax-errors/object-destructure.js
+++ b/src/tests/zustand-pick-from/syntax-errors/object-destructure.js
@@ -1,0 +1,1 @@
+const { order } = useGlobalStore.pickFrom();

--- a/src/tests/zustand-pick-from/syntax-errors/pick-from-multiple-arguments.js
+++ b/src/tests/zustand-pick-from/syntax-errors/pick-from-multiple-arguments.js
@@ -1,0 +1,1 @@
+const user = useGlobalStore.pickFrom("order", "user");

--- a/src/tests/zustand-pick-from/syntax-errors/pick-from-path-array-expressions.js
+++ b/src/tests/zustand-pick-from/syntax-errors/pick-from-path-array-expressions.js
@@ -1,0 +1,1 @@
+const user = useGlobalStore.pickFrom(["order", index + 1]);

--- a/src/tests/zustand-pick-from/syntax-errors/pick-from-path-array-templates.js
+++ b/src/tests/zustand-pick-from/syntax-errors/pick-from-path-array-templates.js
@@ -1,0 +1,1 @@
+const user = useGlobalStore.pickFrom(["order", `#${orderId}`]);

--- a/src/tests/zustand-pick-from/transformations/array-pick-from/input.js
+++ b/src/tests/zustand-pick-from/transformations/array-pick-from/input.js
@@ -1,0 +1,1 @@
+const order = useGlobalStore.pickFrom(["state", sessionId, "current", data]);

--- a/src/tests/zustand-pick-from/transformations/array-pick-from/output.js
+++ b/src/tests/zustand-pick-from/transformations/array-pick-from/output.js
@@ -1,0 +1,3 @@
+const order = useGlobalStore(
+  store => store["state"]?.[sessionId]?.["current"]?.[data]?.["order"]
+);

--- a/src/tests/zustand-pick-from/transformations/dynamic-pick-from/input.js
+++ b/src/tests/zustand-pick-from/transformations/dynamic-pick-from/input.js
@@ -1,0 +1,1 @@
+const customer = useGlobalStore.pickFrom(sessionId);

--- a/src/tests/zustand-pick-from/transformations/dynamic-pick-from/output.js
+++ b/src/tests/zustand-pick-from/transformations/dynamic-pick-from/output.js
@@ -1,0 +1,1 @@
+const customer = useGlobalStore(store => store[sessionId]?.["customer"]);

--- a/src/tests/zustand-pick-from/transformations/empty-pick-from/input.js
+++ b/src/tests/zustand-pick-from/transformations/empty-pick-from/input.js
@@ -1,0 +1,1 @@
+const order = useGlobalStore.pickFrom();

--- a/src/tests/zustand-pick-from/transformations/empty-pick-from/output.js
+++ b/src/tests/zustand-pick-from/transformations/empty-pick-from/output.js
@@ -1,0 +1,1 @@
+const order = useGlobalStore(store => store["order"]);

--- a/src/tests/zustand-pick-from/transformations/string-pick-from/input.js
+++ b/src/tests/zustand-pick-from/transformations/string-pick-from/input.js
@@ -1,0 +1,1 @@
+const order = useGlobalStore.pickFrom("state");

--- a/src/tests/zustand-pick-from/transformations/string-pick-from/output.js
+++ b/src/tests/zustand-pick-from/transformations/string-pick-from/output.js
@@ -1,0 +1,1 @@
+const order = useGlobalStore(store => store["state"]?.["order"]);

--- a/src/tests/zustand-pick-from/zustand-pick-from.spec.js
+++ b/src/tests/zustand-pick-from/zustand-pick-from.spec.js
@@ -1,0 +1,18 @@
+const { pluginTester } = require("babel-plugin-tester");
+
+const { INCORRECT_ZUSTAND_PICK_FROM_USAGE } = require("../../plugins/messages");
+const zustandPickFrom = require("../../plugins/zustand-pick-from");
+const {
+  getPositiveCases,
+  getNegativeCases,
+  getIncorrectSyntaxCases,
+} = require("../utils");
+
+pluginTester({
+  plugin: zustandPickFrom,
+  tests: {
+    ...getPositiveCases(__dirname),
+    ...getIncorrectSyntaxCases(__dirname, INCORRECT_ZUSTAND_PICK_FROM_USAGE),
+    ...getNegativeCases(__dirname),
+  },
+});


### PR DESCRIPTION
- Fixes #10 

**Description**
Added zustand `pickFrom` transformer to pick a single item from store without transpiling to the boilerplate code of `pick` transform.

**Checklist**

- [x] I have made corresponding changes to the documentation.
- [ ] I have verified the functionality in some of the neeto web-apps.
- [x] I have added the necessary label (patch/minor/major - If package publish
      is required).

**Reviewers**

<!---
------------- NOTES -------------
1. Do not add a patch/minor/major label if a release is not required.
2. Strike through the points ~~like this~~ if not applicable.
--->
