### PR TITLE
Add paths to default NeetoCI workflow

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,31 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - app/**
+  - bin/**
+  - config/**
+  - db/**
+  - lib/**
+  - test/**
+  - .neetoci/default.yml
+  - .neetoci/scripts/run_eslint_on_modified_files.sh
+  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
+  - .neetoci/scripts/check_schema_drift.sh
+  - Gemfile*
+  - package.json
+  - yarn.lock
+  - Rakefile
+  - .env.test
+  - config.ru
+  - .*.yml
+  - .ruby-version
+  - .node-version
+  - .nvmrc
+  - .active_record_doctor.rb
+  - .prettierrc.js
+  - "*.config.*"
+
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -26,6 +26,8 @@ paths:
   - .active_record_doctor.rb
   - .prettierrc.js
   - "*.config.*"
+  - .eslintignore
+  - .eslintrc.js
 
 global_job_config:
   setup:


### PR DESCRIPTION
## Summary

Adds `paths:` to `.neetoci/default.yml` so default CI runs **only** when at least one code file changes. Non-code files (README, docs, markdown, agent metadata, etc.) no longer trigger default checks.

## What triggers CI

- `app/**`, `config/**`, `db/**`, `lib/**`, `test/**`
- `.neetoci/default.yml` and CI scripts
- `Gemfile*`, `package.json`, `yarn.lock`
- Config files: `.*.yml`, `*.config.*`, `.ruby-version`, `.node-version`, etc.

## What no longer triggers CI

- `README.md`, `**/*.md`, `docs/**`
- `.claude/**`, `.cursor/**`, `.vscode/**`
- Any other non-code file

Part of neetozone/neeto-engineering#1970

🤖 Generated with [Claude Code](https://claude.com/claude-code)