### PR TITLE
Fix .neetoci paths filter (supersedes #67)

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,33 +2,6 @@ version: v1.0
 
 plan: standard-2
 
-paths:
-  - app/**
-  - bin/**
-  - config/**
-  - db/**
-  - lib/**
-  - test/**
-  - .neetoci/default.yml
-  - .neetoci/scripts/run_eslint_on_modified_files.sh
-  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
-  - .neetoci/scripts/check_schema_drift.sh
-  - Gemfile*
-  - package.json
-  - yarn.lock
-  - Rakefile
-  - .env.test
-  - config.ru
-  - .*.yml
-  - .ruby-version
-  - .node-version
-  - .nvmrc
-  - .active_record_doctor.rb
-  - .prettierrc.js
-  - "*.config.*"
-  - .eslintignore
-  - .eslintrc.js
-
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,22 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - src/**
+  - index.js
+  - .scripts/**
+  - .neetoci/default.yml
+  - package.json
+  - yarn.lock
+  - .node-version
+  - .nvmrc
+  - .eslintignore
+  - .eslintrc.js
+  - .prettierignore
+  - .prettierrc.js
+  - jsconfig.json
+  - "*.config.*"
+
 global_job_config:
   setup:
     - checkout


### PR DESCRIPTION
## What was wrong

#67 added a generic, copy-pasted `paths:` filter written for a Rails+JS stack (see neetozone/neeto-engineering#1970). babel-preset-neeto is a pure JS babel preset with no Rails app -- `app/**`, `bin/**`, `config/**`, `db/**`, `lib/**`, `test/**`, `Gemfile*`, etc. don't apply. It also hardcoded `.neetoci/scripts/*.sh` filenames, but this repo has no `.neetoci/scripts/` directory at all -- the real eslint script is `.scripts/run_eslint_on_modified_files.sh`. The old filter would essentially never have matched a genuine change to this repo's source or CI script.

## What changed

Reverts #67 and re-adds a `paths:` list scoped to the real layout: `src/**`, `index.js`, `.scripts/**` (glob instead of hardcoded filenames), `.neetoci/default.yml`, and the JS tooling config that actually exists here (`package.json`, `yarn.lock`, `.node-version`, `.nvmrc`, `.eslintignore`, `.eslintrc.js`, `.prettierignore`, `.prettierrc.js`, `jsconfig.json`, `*.config.*`).

Refs neetozone/neeto-engineering#1970