### PR TITLE
Renamed CI workflows from default to verify and playwright-typecheck

### DIFF
--- a/.neetoci/verify.yml
+++ b/.neetoci/verify.yml
@@ -6,7 +6,7 @@ paths:
   - src/**
   - index.js
   - .scripts/**
-  - .neetoci/default.yml
+  - .neetoci/verify.yml
   - package.json
   - yarn.lock
   - .node-version


### PR DESCRIPTION
- Part of neetozone/neeto-engineering#2041

Renamed `.neetoci/default.yml` to `.neetoci/verify.yml` so the CI workflow name says what it runs instead of "default". Also renamed `.neetoci/playwright-default.yml` to `.neetoci/playwright-typecheck.yml`, since that workflow only runs `npx tsc` against the Playwright suite and never launches Playwright.
